### PR TITLE
Testing whether there are multiple anylogger instances floating around

### DIFF
--- a/application/index.ts
+++ b/application/index.ts
@@ -5,6 +5,11 @@ import { log } from 'myLib';
 // The instance of anylogger in myLib doesn't seem to be affected by any adapters
 log('hello from myLib log in application');
 
+
 // To demonstrate `anylogger-console` working as expected from application
 const applog = anylogger('application');
 applog('hello directly from applog in application');
+
+applog('log.name=', log.name)
+applog('log.name in anylogger', log.name in anylogger)
+applog('anylogger.justTesting=', (anylogger as any).justTesting)

--- a/application/package.json
+++ b/application/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "start": "log=debug nodemon index.ts",
-    "start:node": "npm run build && log=debug node dist/index.js"
+    "start": "nodemon index.ts",
+    "start:node": "npm run build && node dist/index.js"
   },
   "keywords": [],
   "author": "",

--- a/myLib/src/helpers/logging.ts
+++ b/myLib/src/helpers/logging.ts
@@ -1,5 +1,7 @@
 import anylogger from 'anylogger';
+import { isConstructorDeclaration } from 'typescript';
 
+(anylogger as any).justTesting = 'Let\'s try something';
 const log = anylogger('myLib');
-
+console.info('anylogger.justTesting=', (anylogger as any).justTesting)
 export default log;

--- a/myLib/tsconfig.json
+++ b/myLib/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "lib": ["ES2018"],
+    "lib": ["ES2018","DOM"],
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,


### PR DESCRIPTION
Output after the changes:

```sh
c:\ws\anylogger-bug-repro-17\application>npm start

> delete-me-anylogger-recreation@1.0.0 start c:\ws\anylogger-bug-repro-17\application
> nodemon index.ts

[nodemon] 2.0.7
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): *.*
[nodemon] watching extensions: ts,json
[nodemon] starting `ts-node index.ts`
anylogger.justTesting= Let's try something
hello directly from applog in application
log.name= myLib
log.name in anylogger false
anylogger.justTesting= undefined
[nodemon] clean exit - waiting for changes before restart
```

(I removed the log=debug because it should have no effect anyway and made my command fail in Windows)
