### PR TITLE
Public package fix

### DIFF
--- a/application/index.ts
+++ b/application/index.ts
@@ -1,6 +1,6 @@
 import anylogger from 'anylogger';
 import 'anylogger-console';
-import { log } from 'myLib';
+import { log } from 'anylogger-bug-repro-17-my-lib';
 
 // The instance of anylogger in myLib doesn't seem to be affected by any adapters
 log('hello from myLib log in application');

--- a/application/index.ts
+++ b/application/index.ts
@@ -5,6 +5,11 @@ import { log } from 'myLib';
 // The instance of anylogger in myLib doesn't seem to be affected by any adapters
 log('hello from myLib log in application');
 
+
 // To demonstrate `anylogger-console` working as expected from application
 const applog = anylogger('application');
 applog('hello directly from applog in application');
+
+applog('log.name=', log.name)
+applog('log.name in anylogger', log.name in anylogger)
+applog('anylogger.justTesting=', (anylogger as any).justTesting)

--- a/application/index.ts
+++ b/application/index.ts
@@ -9,7 +9,3 @@ log('hello from myLib log in application');
 // To demonstrate `anylogger-console` working as expected from application
 const applog = anylogger('application');
 applog('hello directly from applog in application');
-
-applog('log.name=', log.name)
-applog('log.name in anylogger', log.name in anylogger)
-applog('anylogger.justTesting=', (anylogger as any).justTesting)

--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -68,9 +68,9 @@
       "integrity": "sha512-iZsA9nnDpeS6A19W6LcOKqAxk2pbc93rOl4KnfOItmqdvVktv1rNqqOsY7I2j8wjt0slmGnInapKnfmKAifFDw=="
     },
     "anylogger-bug-repro-17-my-lib": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anylogger-bug-repro-17-my-lib/-/anylogger-bug-repro-17-my-lib-1.0.0.tgz",
-      "integrity": "sha512-iZ83gM8J2rIaHJl+7iOfWVtXE+H36/yjkDBsIFTHGiG/8WEn1STVJs0NFvlasyZGzLMbhafREC+M/rPqtDL/og==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anylogger-bug-repro-17-my-lib/-/anylogger-bug-repro-17-my-lib-1.0.1.tgz",
+      "integrity": "sha512-qJ2QF59qHbOcOBNoPNlCLWTlnogwttZnkI6C4PQcAsaCp6X0jJ8gmp1J/kPCF3EbNQYqtYrOHeBz8+tX1lKH3A==",
       "requires": {
         "anylogger": "^1.0.10",
         "typescript": "^4.1.3"

--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -67,6 +67,15 @@
       "resolved": "https://registry.npmjs.org/anylogger/-/anylogger-1.0.10.tgz",
       "integrity": "sha512-iZsA9nnDpeS6A19W6LcOKqAxk2pbc93rOl4KnfOItmqdvVktv1rNqqOsY7I2j8wjt0slmGnInapKnfmKAifFDw=="
     },
+    "anylogger-bug-repro-17-my-lib": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anylogger-bug-repro-17-my-lib/-/anylogger-bug-repro-17-my-lib-1.0.0.tgz",
+      "integrity": "sha512-iZ83gM8J2rIaHJl+7iOfWVtXE+H36/yjkDBsIFTHGiG/8WEn1STVJs0NFvlasyZGzLMbhafREC+M/rPqtDL/og==",
+      "requires": {
+        "anylogger": "^1.0.10",
+        "typescript": "^4.1.3"
+      }
+    },
     "anylogger-console": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/anylogger-console/-/anylogger-console-1.0.0.tgz",
@@ -639,25 +648,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
-    },
-    "myLib": {
-      "version": "file:../myLib",
-      "requires": {
-        "anylogger": "^1.0.10",
-        "typescript": "^4.1.3"
-      },
-      "dependencies": {
-        "anylogger": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/anylogger/-/anylogger-1.0.10.tgz",
-          "integrity": "sha512-iZsA9nnDpeS6A19W6LcOKqAxk2pbc93rOl4KnfOItmqdvVktv1rNqqOsY7I2j8wjt0slmGnInapKnfmKAifFDw=="
-        },
-        "typescript": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-          "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
-        }
-      }
     },
     "nodemon": {
       "version": "2.0.7",

--- a/application/package.json
+++ b/application/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc",
-    "start": "log=debug nodemon index.ts",
-    "start:node": "npm run build && log=debug node dist/index.js"
+    "start": "nodemon index.ts",
+    "start:node": "npm run build && node dist/index.js"
   },
   "keywords": [],
   "author": "",

--- a/application/package.json
+++ b/application/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "anylogger": "^1.0.10",
     "anylogger-console": "^1.0.0",
-    "myLib": "../myLib",
+    "anylogger-bug-repro-17-my-lib": "^1.0.0",
     "typescript": "^4.1.3"
   },
   "devDependencies": {

--- a/application/package.json
+++ b/application/package.json
@@ -13,8 +13,8 @@
   "license": "ISC",
   "dependencies": {
     "anylogger": "^1.0.10",
+    "anylogger-bug-repro-17-my-lib": "^1.0.1",
     "anylogger-console": "^1.0.0",
-    "anylogger-bug-repro-17-my-lib": "^1.0.0",
     "typescript": "^4.1.3"
   },
   "devDependencies": {

--- a/myLib/package-lock.json
+++ b/myLib/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "anylogger-bug-repro-17-my-lib",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/myLib/package-lock.json
+++ b/myLib/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "myLib",
+  "name": "anylogger-bug-repro-17-my-lib",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/myLib/package.json
+++ b/myLib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "myLib",
+  "name": "anylogger-bug-repro-17-my-lib",
   "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",

--- a/myLib/package.json
+++ b/myLib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anylogger-bug-repro-17-my-lib",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/myLib/src/helpers/logging.ts
+++ b/myLib/src/helpers/logging.ts
@@ -1,5 +1,7 @@
 import anylogger from 'anylogger';
+import { isConstructorDeclaration } from 'typescript';
 
+(anylogger as any).justTesting = 'Let\'s try something';
 const log = anylogger('myLib');
-
+console.info('anylogger.justTesting=', (anylogger as any).justTesting)
 export default log;

--- a/myLib/src/helpers/logging.ts
+++ b/myLib/src/helpers/logging.ts
@@ -1,7 +1,5 @@
 import anylogger from 'anylogger';
-import { isConstructorDeclaration } from 'typescript';
 
-(anylogger as any).justTesting = 'Let\'s try something';
 const log = anylogger('myLib');
-console.info('anylogger.justTesting=', (anylogger as any).justTesting)
+
 export default log;

--- a/myLib/tsconfig.json
+++ b/myLib/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2018",
-    "lib": ["ES2018"],
+    "lib": ["ES2018","DOM"],
     "module": "commonjs",
     "esModuleInterop": true,
     "declaration": true,


### PR DESCRIPTION
This PR turns myLib into a real package on NPM, i.s.o one that's symlinked in. That fixes the issue.

I actually went ahead and published this to NPM:
https://www.npmjs.com/package/anylogger-bug-repro-17-my-lib
Then made application use that 'real' package instead and voila:

```sh
C:\ws\anylogger-bug-repro-17>cd myLib

C:\ws\anylogger-bug-repro-17\myLib>npm install
npm WARN anylogger-bug-repro-17-my-lib@1.0.1 No description
npm WARN anylogger-bug-repro-17-my-lib@1.0.1 No repository field.

audited 2 packages in 0.477s
found 0 vulnerabilities


C:\ws\anylogger-bug-repro-17\myLib>npm run build

> anylogger-bug-repro-17-my-lib@1.0.1 build C:\ws\anylogger-bug-repro-17\myLib
> tsc


C:\ws\anylogger-bug-repro-17\myLib>npm publish
npm notice
npm notice package: anylogger-bug-repro-17-my-lib@1.0.1
npm notice === Tarball Contents ===
npm notice 377B dist/index.js
npm notice 383B dist/helpers/logging.js
npm notice 289B package.json
npm notice 553B tsconfig.json
npm notice 141B dist/index.js.map
npm notice 202B dist/helpers/logging.js.map
npm notice 55B  dist/index.d.ts
npm notice 54B  src/index.ts
npm notice 101B dist/helpers/logging.d.ts
npm notice 89B  src/helpers/logging.ts
npm notice === Tarball Details ===
npm notice name:          anylogger-bug-repro-17-my-lib
npm notice version:       1.0.1
npm notice package size:  1.2 kB
npm notice unpacked size: 2.2 kB
npm notice shasum:        d108383c524be39c015f7badf202a38e73ba5cd6
npm notice integrity:     sha512-qJ2QF59qHbOcO[...]eBz8+tX1lKH3A==
npm notice total files:   10
npm notice
+ anylogger-bug-repro-17-my-lib@1.0.1

C:\ws\anylogger-bug-repro-17\myLib>cd ..

C:\ws\anylogger-bug-repro-17>cd application

C:\ws\anylogger-bug-repro-17\application>npm install
npm WARN delete-me-anylogger-recreation@1.0.0 No description
npm WARN delete-me-anylogger-recreation@1.0.0 No repository field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@2.3.1 (node_modules\fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.1: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"})

updated 1 package and audited 134 packages in 1.893s

11 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities


C:\ws\anylogger-bug-repro-17\application>npm run build

> delete-me-anylogger-recreation@1.0.0 build C:\ws\anylogger-bug-repro-17\application
> tsc


C:\ws\anylogger-bug-repro-17\application>npm start

> delete-me-anylogger-recreation@1.0.0 start C:\ws\anylogger-bug-repro-17\application
> nodemon index.ts

[nodemon] 2.0.7
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): *.*
[nodemon] watching extensions: ts,json
[nodemon] starting `ts-node index.ts`
hello from myLib log in application
hello directly from applog in application
[nodemon] clean exit - waiting for changes before restart
```

The underlying issue is that when used via a symlink, NPM does not use `application/node_modules/anylogger` but `myLib/node_modules/anylogger` when anylogger is imported from anywhere inside the myLib folder. This is not the same behavior as for regular packages, as this PR proves. 

This might be a bug in NPM's handling of symlinked dependencies. I'm not sure. I can definitely appreciate the advantages symlinked in dependencies would / could bring if they were implemented correctly, but I have long ago given up on this option with NPM because I ran into problems similar to this and did not find the time to solve them. What you might try, is create a single `./node_modules` folder, then symlink `./application/node_modules` and `./myLib/node_modules` to that common folder. Maybe that would work.

The bottom line is that you have to make sure the same node_modules tree is used from imports from both projects and as it stands that does not seem to be the case in this particular setup.

